### PR TITLE
Fix error handling when decoding server.secret.

### DIFF
--- a/padlockcloud/server.go
+++ b/padlockcloud/server.go
@@ -428,9 +428,9 @@ func (server *Server) Init() error {
 
 	if server.Config.Secret != "" {
 		if s, err := base64.StdEncoding.DecodeString(server.Config.Secret); err != nil {
-			server.secret = s
-		} else {
 			return err
+		} else {
+			server.secret = s
 		}
 	} else {
 		if key, err := randomBytes(32); err != nil {

--- a/padlockcloud/server_test.go
+++ b/padlockcloud/server_test.go
@@ -2,6 +2,7 @@ package padlockcloud
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1008,5 +1009,14 @@ func TestDeviceData(t *testing.T) {
 
 	if !reflect.DeepEqual(ctx.device, token.Device) {
 		t.Errorf("Device data not updated correctly! Expected: %+v, got: %+v", ctx.device, token.Device)
+	}
+}
+
+func TestSecretInConfig(t *testing.T) {
+	secret := bytes.Repeat([]byte("a"), 32)
+	ctx := newServerTestContextWithConfig(&ServerConfig{Secret: base64.StdEncoding.EncodeToString(secret)})
+
+	if !bytes.Equal(ctx.server.secret, secret) {
+		t.Errorf("User-provided secret not set in server. Expected: %q, got: %q", secret, ctx.server.secret)
 	}
 }


### PR DESCRIPTION
The two code paths (err != nil and err == nil) are swapped. As a result,
specifying a valid base64 secret in the config does not work.