### PR TITLE
Separate user for mail authentication and mail sender, and make the former optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ leveldb:
   path: path/to/db
 email:
   server: smtp.gmail.com
-  port : "587"
-  user: mail@example.com
+  port: "587"
+  user: mail_user
   password: secret
+  from: mail@example.com
 log:
   log_file: LOG.txt
   err_file: ERR.txt

--- a/padlockcloud/cli.go
+++ b/padlockcloud/cli.go
@@ -59,9 +59,7 @@ func (cliApp *CliApp) InitServer() error {
 		cliApp.Config.Server.Cors = true
 	} else {
 		storage = cliApp.Storage
-		sender = &EmailSender{
-			Config: &cliApp.Config.Email,
-		}
+		sender = NewEmailSender(&cliApp.Config.Email)
 		logger.Sender = sender
 	}
 

--- a/padlockcloud/cli.go
+++ b/padlockcloud/cli.go
@@ -270,6 +270,13 @@ func NewCliApp() *CliApp {
 			Destination: &config.Email.Password,
 		},
 		cli.StringFlag{
+			Name:        "email-from",
+			Value:       "",
+			Usage:       "Mail address to use as sender of outgoing mails. If empty, email-user is used instead.",
+			EnvVar:      "PC_EMAIL_FROM",
+			Destination: &config.Email.From,
+		},
+		cli.StringFlag{
 			Name:        "whitelist-path",
 			Value:       "",
 			Usage:       "File containing line-separated email whitelist",

--- a/padlockcloud/cli_test.go
+++ b/padlockcloud/cli_test.go
@@ -37,6 +37,7 @@ func NewSampleConfig(dir string) CliConfig {
 			Password: "emailpassword",
 			Server:   "myemailserver.com",
 			Port:     "4321",
+			From:     "emailfrom",
 		},
 	}
 }

--- a/padlockcloud/sender.go
+++ b/padlockcloud/sender.go
@@ -40,12 +40,15 @@ func NewEmailSender(c *EmailConfig) *EmailSender {
 
 // Attempts to send an email to a given recipient.
 func (sender *EmailSender) Send(rec string, subject string, body string) error {
-	auth := smtp.PlainAuth(
-		"",
-		sender.Config.User,
-		sender.Config.Password,
-		sender.Config.Server,
-	)
+	var auth smtp.Auth
+	if sender.Config.User != "" {
+		auth = smtp.PlainAuth(
+			"",
+			sender.Config.User,
+			sender.Config.Password,
+			sender.Config.Server,
+		)
+	}
 
 	from := sender.Config.From
 	if from == "" {

--- a/padlockcloud/sender.go
+++ b/padlockcloud/sender.go
@@ -18,6 +18,8 @@ type EmailConfig struct {
 	Port string `yaml:"port"`
 	// Password used for authentication with the mail server
 	Password string `yaml:"password"`
+	// Sender mail address for outgoing mails. If empty, `User` is used instead.
+	From string `yaml:"from"`
 }
 
 // EmailSender implements the `Sender` interface for emails
@@ -45,11 +47,16 @@ func (sender *EmailSender) Send(rec string, subject string, body string) error {
 		sender.Config.Server,
 	)
 
-	message := fmt.Sprintf("Subject: %s\r\nFrom: Padlock Cloud <%s>\r\n\r\n%s", subject, sender.Config.User, body)
+	from := sender.Config.From
+	if from == "" {
+		from = sender.Config.User
+	}
+
+	message := fmt.Sprintf("Subject: %s\r\nFrom: Padlock Cloud <%s>\r\n\r\n%s", subject, from, body)
 	return sender.SendFunc(
 		sender.Config.Server+":"+sender.Config.Port,
 		auth,
-		sender.Config.User,
+		from,
 		[]string{rec},
 		[]byte(message),
 	)

--- a/padlockcloud/sender_test.go
+++ b/padlockcloud/sender_test.go
@@ -90,6 +90,24 @@ func TestEmailSenderSendBuildsPlainAuth(t *testing.T) {
 	}
 }
 
+func TestEmailSenderNoUserNoAuth(t *testing.T) {
+	sender := NewEmailSender(&EmailConfig{
+		// No `User`: disable authentication.
+		Server:   "unused_server",
+		Port:     "unused_port",
+		Password: "unused_password",
+	})
+	sender.SendFunc = func(_ string, a smtp.Auth, _ string, _ []string, _ []byte) error {
+		if a != nil {
+			t.Errorf("SendFunc auth: got %q; want nil", a)
+		}
+		return nil
+	}
+	if err := sender.Send("unused_recipient", "unused_subject", "unused_body"); err != nil {
+		t.Errorf("Send() == %v; want nil", err)
+	}
+}
+
 func TestEmailSenderSendFailsWhenSendMailFails(t *testing.T) {
 	sender := NewEmailSender(&EmailConfig{
 		User:     "user",

--- a/padlockcloud/sender_test.go
+++ b/padlockcloud/sender_test.go
@@ -14,13 +14,14 @@ func TestEmailSenderSendCallsSendMailCorrectly(t *testing.T) {
 		Server:   "test_server",
 		Port:     "test_port",
 		Password: "unused_password",
+		From:     "test_from",
 	})
 	sender.SendFunc = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
 		if want := "test_server:test_port"; addr != want {
 			t.Errorf("SendFunc addr: got %q; want %q", addr, want)
 		}
 		// smtp.Auth is tested in a separate test.
-		if want := "test_user"; from != want {
+		if want := "test_from"; from != want {
 			t.Errorf("SendFunc from: got %q; want %q", from, want)
 		}
 		if want := []string{"test_recipient"}; !reflect.DeepEqual(to, want) {
@@ -37,6 +38,26 @@ func TestEmailSenderSendCallsSendMailCorrectly(t *testing.T) {
 	if err := sender.Send("test_recipient", "test_subject", "test_body"); err != nil {
 		t.Errorf("Send() == %v; want nil", err)
 	}
+}
+
+func TestEmailSenderSendFallsBackToUserWhenNoFrom(t *testing.T) {
+	sender := NewEmailSender(&EmailConfig{
+		User:     "test_user",
+		Server:   "unused_server",
+		Port:     "unused_port",
+		Password: "unused_password",
+		// No `From`: fall back to `User`.
+	})
+	sender.SendFunc = func(_ string, _ smtp.Auth, from string, _ []string, _ []byte) error {
+		if want := "test_user"; from != want {
+			t.Errorf("SendFunc from: got %q; want %q", from, want)
+		}
+		return nil
+	}
+	if err := sender.Send("test_recipient", "test_subject", "test_body"); err != nil {
+		t.Errorf("Send() == %v; want nil", err)
+	}
+
 }
 
 // This is tested separately as it relies on implementation details of smtp.PlainAuth.
@@ -64,7 +85,7 @@ func TestEmailSenderSendBuildsPlainAuth(t *testing.T) {
 		}
 		return nil
 	}
-	if err := sender.Send("test_recipient", "test_subject", "test_body"); err != nil {
+	if err := sender.Send("unused_recipient", "unused_subject", "unused_body"); err != nil {
 		t.Errorf("Send() == %v; want nil", err)
 	}
 }
@@ -75,6 +96,7 @@ func TestEmailSenderSendFailsWhenSendMailFails(t *testing.T) {
 		Server:   "server",
 		Port:     "42",
 		Password: "password",
+		From:     "unused_from",
 	})
 	want := errors.New("jabberwock")
 	sender.SendFunc = func(string, smtp.Auth, string, []string, []byte) error {

--- a/padlockcloud/sender_test.go
+++ b/padlockcloud/sender_test.go
@@ -1,0 +1,86 @@
+package padlockcloud
+
+import (
+	"bytes"
+	"errors"
+	"net/smtp"
+	"reflect"
+	"testing"
+)
+
+func TestEmailSenderSendCallsSendMailCorrectly(t *testing.T) {
+	sender := NewEmailSender(&EmailConfig{
+		User:     "test_user",
+		Server:   "test_server",
+		Port:     "test_port",
+		Password: "unused_password",
+	})
+	sender.SendFunc = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+		if want := "test_server:test_port"; addr != want {
+			t.Errorf("SendFunc addr: got %q; want %q", addr, want)
+		}
+		// smtp.Auth is tested in a separate test.
+		if want := "test_user"; from != want {
+			t.Errorf("SendFunc from: got %q; want %q", from, want)
+		}
+		if want := []string{"test_recipient"}; !reflect.DeepEqual(to, want) {
+			t.Errorf("SendFunc to: got %q; want %q", to, want)
+		}
+		if want := []byte("test_subject"); !bytes.Contains(msg, want) {
+			t.Errorf("SendFunc msg: got %q; want contains %q", msg, want)
+		}
+		if want := []byte("test_body"); !bytes.Contains(msg, want) {
+			t.Errorf("SendFunc msg: got %q; want contains %q", msg, want)
+		}
+		return nil
+	}
+	if err := sender.Send("test_recipient", "test_subject", "test_body"); err != nil {
+		t.Errorf("Send() == %v; want nil", err)
+	}
+}
+
+// This is tested separately as it relies on implementation details of smtp.PlainAuth.
+// One way to make this test less brittle is to inject the auth dependency in EmailSender.
+func TestEmailSenderSendBuildsPlainAuth(t *testing.T) {
+	sender := NewEmailSender(&EmailConfig{
+		User:     "test_user",
+		Server:   "test_server",
+		Port:     "unused_port",
+		Password: "test_password",
+	})
+	sender.SendFunc = func(addr string, a smtp.Auth, from string, to []string, msg []byte) error {
+		_, toServer, err := a.Start(&smtp.ServerInfo{
+			TLS:  true,
+			Name: "test_server",
+		})
+		if err != nil {
+			t.Fatalf("SendFunc auth: call to Start(): got %v; want nil", err)
+		}
+		if want := []byte("test_user"); !bytes.Contains(toServer, want) {
+			t.Errorf("SendFunc auth: PlainAuth toServer: got %q; want contains %q", toServer, want)
+		}
+		if want := []byte("test_password"); !bytes.Contains(toServer, want) {
+			t.Errorf("SendFunc auth: PlainAuth toServer: got %q; want contains %q", toServer, want)
+		}
+		return nil
+	}
+	if err := sender.Send("test_recipient", "test_subject", "test_body"); err != nil {
+		t.Errorf("Send() == %v; want nil", err)
+	}
+}
+
+func TestEmailSenderSendFailsWhenSendMailFails(t *testing.T) {
+	sender := NewEmailSender(&EmailConfig{
+		User:     "user",
+		Server:   "server",
+		Port:     "42",
+		Password: "password",
+	})
+	want := errors.New("jabberwock")
+	sender.SendFunc = func(string, smtp.Auth, string, []string, []byte) error {
+		return want
+	}
+	if err := sender.Send("recipient", "subject", "body"); err != want {
+		t.Errorf("sender.Send(): got %v; want %v", err, want)
+	}
+}


### PR DESCRIPTION
This PR makes sending mails a bit more flexible.
- It allows to disable SMTP authentication (e.g. for localhost).
- It separates user for SMTP authentication and mail sender (sometimes they're not the same, and sometimes there is no authentication, see above).
- It makes the EmailSender type testable and adds some tests.